### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "class-validator": "^0.14.1",
     "mongoose": "^8.9.5",
     "rxjs": "^7.8.1",
-    "serialport": "^13.0.0"
+    "serialport": "^13.0.0",
+    "joi": "^17.13.3"
   },
   "devDependencies": {
     "@dmx-cloud/dmx-types": "^0.30.0",


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/vs-kurkin/dmx-backend/security/code-scanning/1](https://github.com/vs-kurkin/dmx-backend/security/code-scanning/1)

To fix the problem, we need to ensure that the user-provided `device` object is sanitized and validated before being used in the database query. This can be achieved by explicitly checking the structure and content of the `device` object before passing it to the `replaceOne` method.

The best way to fix this issue is to validate the `device` object in the `updateDevice` method of `DeviceService` before using it in the query. We can use a library like `Joi` for schema validation to ensure that the `device` object conforms to the expected structure and does not contain any malicious content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added validation for `device` object in `updateDevice` method.

- Introduced `Joi` schema validation to ensure data integrity.

- Updated `package.json` to include `joi` as a dependency.

- Enhanced error handling for invalid `device` data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device.ts</strong><dd><code>Added `device` validation and error handling in `DeviceService`</code></dd></summary>
<hr>

src/services/device.ts

<li>Added <code>validateDevice</code> method using <code>Joi</code> for schema validation.<br> <li> Integrated validation in <code>updateDevice</code> method to sanitize input.<br> <li> Enhanced error handling for invalid <code>device</code> data.<br> <li> Imported <code>Joi</code> library for validation purposes.


</details>


  </td>
  <td><a href="https://github.com/vs-kurkin/dmx-backend/pull/10/files#diff-be75a92c5ea2159c21a72dae66b5150902ab6f26e06300e37faa9de074cde26f">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Added `joi` dependency for validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added `joi` library as a new dependency.


</details>


  </td>
  <td><a href="https://github.com/vs-kurkin/dmx-backend/pull/10/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>