### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/src/services/device.ts
+++ b/src/services/device.ts
@@ -111,7 +111,7 @@ export default class DeviceService {
 
     const doc = await this.getDeviceByIndex(index)
 
-    await doc.replaceOne({ $set: device }, { runValidators: true })
+    await doc.replaceOne({ $set: { $eq: device } }, { runValidators: true })
     await doc.save()
   }
 

--- a/src/services/device.ts
+++ b/src/services/device.ts
@@ -103,15 +103,15 @@ export default class DeviceService {
    * @param device The updated device
    */
   async updateDevice(index: DeviceIndex, device: Device) {
-    const doc = await this.getDeviceByIndex(index)
-
     // Validate the device object
     const { error } = this.validateDevice(device)
     if (error) {
       throw new Error(`Invalid device data: ${error.message}`)
     }
 
-    await doc.replaceOne(device, { runValidators: true })
+    const doc = await this.getDeviceByIndex(index)
+
+    await doc.replaceOne({ $set: device }, { runValidators: true })
     await doc.save()
   }
 


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/vs-kurkin/dmx-backend/security/code-scanning/1](https://github.com/vs-kurkin/dmx-backend/security/code-scanning/1)

To fix the problem, we need to ensure that the `device` object is properly validated before it is used in any database query. This can be achieved by moving the validation step before the `replaceOne` query in the `updateDevice` method. Additionally, we should use the `$set` operator to ensure that the `device` object is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes a security vulnerability in `updateDevice` method.

- Validates the `device` object before database query execution.

- Ensures the `device` object is treated as a literal using `$set` operator.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device.ts</strong><dd><code>Secure `updateDevice` method with validation and `$set` operator</code></dd></summary>
<hr>

src/services/device.ts

<li>Moved <code>device</code> validation before database query execution.<br> <li> Replaced direct <code>replaceOne</code> call with <code>$set</code> operator for safety.<br> <li> Ensured proper validation and secure handling of user-controlled data.


</details>


  </td>
  <td><a href="https://github.com/vs-kurkin/dmx-backend/pull/15/files#diff-be75a92c5ea2159c21a72dae66b5150902ab6f26e06300e37faa9de074cde26f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>